### PR TITLE
Update-Olin-Flying-Club.md

### DIFF
--- a/charters/Olin-Flying-Club.md
+++ b/charters/Olin-Flying-Club.md
@@ -1,13 +1,13 @@
 # Olin Flying Club
-*Last modified 2016-08-31*
+*Last modified 2016-09-27*
 
 ##Purpose
-Olin has an abundance of people who like to aircraft, and a few who fly them. The Olin Flying Club aims to spread the
+Olin has an abundance of people who like  aircraft, and a few who fly them. The Olin Flying Club aims to spread the
 love of flying, and to make it more accessible to those who fly, are learning to fly, or want to fly.
 
 ##Membership
 We welcome anyone to join Olin Flying Club. We welcome Pilots (both licensed and in training) to profit from shared resources,
-and for those who are interested in learning, or who just want to fly to join us as passengers.
+and for those who are interested in learning, or who just want to share the love of flying to join us to learn from the pilots.
 
 ##Officers and Roles
 President: During the startup period, one officer will be appointed (henceforth known as "Pilot In Command"),
@@ -15,19 +15,15 @@ The PIC will organise club activities and delegate responsibilities as they see 
 forwards under the discretion of the PIC.
 
 ##Transition Protocol
-The PIC will not act alone during their last semester at Olin. An SIC (Second in Command) must assist the PIC to ensure that
-the knowledge of the PIC is not lost, and the PIC seat not left empty when they retire.
+The PIC will not act alone during their last semester at Olin, or in the semester before an LOA/study abroad. An SIC (Second in Command) must assist the PIC to ensure that the knowledge of the PIC is not lost, and the PIC seat not be left empty when they retire.
 
 ##Club materials, Purchases, and Space
-The Olin Flying Club will keep a library of literature relevant to pilots, as well as some equipment that
-passengers can borrow on flights. 
-Funding will come from the existing club fund, as well as the personal libraries of the club's pilots, and donations from
-flight schools.
+The Olin Flying Club will keep a library of literature relevant to pilots, as well as some equipment that can be borrowed. Funding will come from the existing club fund, as well as the personal libraries of the club's pilots, and donations from flight schools.
+
+Olin College and any entity that reports to it will not pay for flights, these fall outside the scope of the club's activities.
 
 ##Events and Activities
-Olin Flying Club will host flights with the licensed Pilots in which non-pilots would be invited to come for the flights.
-Events like flyins involving multiple pilots would also be feasible. Outside of flying, pilots will be invited to share 
-their knowledge and experience with each other, and and those members interested in learning to fly.
+The Olin Flying Club will serve as a social club in which members meet to share knowledge, stories, and experiences. The Olin Flying Club will not host any flying events, nor will these receive any funding through the Olin Flying Club. Any members who fly do so while exercising their rights as pilot's, and in no way represent the Olin Flying Club.
 
 ##Ammendment Procedure
 The charter can be changed at any time following a 50% vote of active members.


### PR DESCRIPTION
Added disclaimers that remove Olin from any liability, and limit the scope of the club's official activities to acting as a social club. Explicitly stating that any flying is done outside of the club's and olin's authority.